### PR TITLE
Return from pre_commit_hook if no files changed.

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -176,6 +176,13 @@ pre_commit_hook() {
   while IFS= read -r file; do
     [ -n "$file" ] && files+=("$file")
   done <<< "$(git diff-index --diff-filter 'ACMU' --name-only --cached $rev --)"
+
+  if [ ${#files[@]} -eq 0 ] || [ ! -z "${options}" ]; then
+    # If no files have changed (e.g., because "git commit --amend" was called to
+    # reword the commit message), exit early. We don't want to scan the entire
+    # working tree in the pre-commit hook.
+    return
+  fi
   scan_with_fn_or_die "scan" "${files[@]}"
 }
 


### PR DESCRIPTION
When "git commit --amend" is used when no files are staged (for example,
to reword a commit message), git-secrets --pre_commit_hook scans the
entire working tree. This is because the scan() function is called with
an empty file list.

For large repos, this causes a bad user experience; the user expects
their editor to open immediately, but instead the pre-commit hook runs
for multiple seconds (9 seconds in the linux kernel on my workstation),
with no progress indication. If the repo contains any previously
committed files that match git-secrets patterns, the editor never opens,
and git-secrets' error message is displayed.

We can make the pre_commit_hook() function return immediately if there
are no changed files, which should match user expectations.

Closes #129

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
