### PR TITLE
Add allowed patterns for common fake account IDs

### DIFF
--- a/git-secrets
+++ b/git-secrets
@@ -258,6 +258,8 @@ register_aws() {
   add_config 'secrets.patterns' "${opt_quote}${aws}(ACCOUNT|account|Account)_?(ID|id|Id)?${opt_quote}${connect}${opt_quote}[0-9]{4}\-?[0-9]{4}\-?[0-9]{4}${opt_quote}"
   add_config 'secrets.allowed' 'AKIAIOSFODNN7EXAMPLE'
   add_config 'secrets.allowed' "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+  add_config 'secrets.allowed' "123456789012"
+  add_config 'secrets.allowed' "012345678912"
 
   if [[ $? == 0 ]]; then
     echo 'OK'


### PR DESCRIPTION

Currently, unit tests which employ a fake AWS account ID will be flagged as validation errors:
```
Gems/AWSCore/Code/Tests/ResourceMapping/AWSResourceMappingManagerTest.cpp:41: "AccountId": "012345678912"
Gems/AWSCore/Code/Tests/ResourceMapping/AWSResourceMappingManagerTest.cpp:57: "AccountId": "123456789012",
Gems/AWSCore/Code/Tests/ResourceMapping/AWSResourceMappingManagerTest.cpp:69: "AccountId": "012345678912"

[ERROR] Matched one or more prohibited patterns

Possible mitigations:

Mark false positives as allowed using: git config --add secrets.allowed ...
```

This change adds exceptions for 2 common fake account ID patterns (both of which occur multiple times in  the O3DE code base) to prevent this from happening.

### Testing
Local testing indicates the previous validation errors are gone.
```
PS C:\Users\USER\source\o3de> git secrets --scan Gems/AWSCore/Code/Tests/ResourceMapping/AWSResourceMappingManagerTest.cpp
PS C:\Users\USER\source\o3de>
```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
